### PR TITLE
[Carried off] m1 hittable fix (#986)

### DIFF
--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -68,17 +68,28 @@ add:
 }
 
 add:
-; --- Block a hole
-; --- 添加入地空气墙
+; --- Block a hole at the back of the building near the fence gate
 {
-    "classname" "env_physics_blocker"
-    "angles" "0 0 0"
-    "BlockType" "0"
-    "maxs" "100 100 272"
-    "mins" "-8 -8 -8"
-    "initialstate" "1"
-    "targetname" "eb_fix1"
-    "origin" "3144 3856 152"
+	"classname" "env_physics_blocker"
+	"angles" "0 0 0"
+	"BlockType" "4"
+	"boxmaxs" "56 240 8"
+	"boxmins" "-8 -8 -180"
+	"initialstate" "1"
+	"targetname" "eb_fix01"
+	"origin" "3144 3848 120"
+}
+; --- Add a clipwall beneath the grass in the tent area
+; --- Prevent hittables from being swallowed
+{
+	"classname" "env_physics_blocker"
+	"angles" "0 0 0"
+	"BlockType" "4"
+	"boxmaxs" "1024 1600 -8.2"
+	"boxmins" "-2400 -600 -128"
+	"initialstate" "1"
+	"targetname" "eb_fix_large_displacement"
+	"origin" "3072 2008 120"
 }
 
 ; ############  DIRECTOR AND EVENT CHANGES  ###########


### PR DESCRIPTION
* [Carried off] m1 hittable fix

Adjust the shape of one clipwall that block a hole at the back of the building near the fence gate, Add a clipwall beneath the grass in the tent area, to prevent hittables from being swallowed

* [Carried off] m1 adjust clipwall type